### PR TITLE
fixed deletion of network group

### DIFF
--- a/amotolani/cisco_fmc/plugins/modules/network_group.py
+++ b/amotolani/cisco_fmc/plugins/modules/network_group.py
@@ -360,6 +360,7 @@ def main():
                 _create_obj = False
             else:
                 changed = True
+                _create_obj = False
 
         requested_config = {
             "literal": group_literals,


### PR DESCRIPTION
whne running module amotolani.cisco_fmc.network_group with state: absent, I get error:

```
fatal: [fmc]: FAILED! => changed=false 
  ansible_facts:
    discovered_interpreter_python: /usr/local/bin/python
  module_stderr: |-
    INFO:root:Requesting new tokens from https://10.177.191.11/api/fmc_platform/v1/auth/generatetoken.
    INFO:root:Building base to URLs.
    INFO:root:Populating vdbVersion, sruVersion, serverVersion, and geoVersion FMC instance variables.
    INFO:root:This FMC's version is 6.6.1 (build 91)
    INFO:root:GET success. Object with name: "dr1-sp-sa-ucs-cimc" and id: "005056A1-EE5E-0ed3-0000-004294981436" fetched from FMC.
    INFO:root:Auto deploy changes set to False.  Use the Deploy button in FMC to push changes to FTDs.
    Traceback (most recent call last):
      File "/home/vscode/.ansible/tmp/ansible-tmp-1655451999.4065552-22141-173774944080067/AnsiballZ_network_group.py", line 102, in <module>
        _ansiballz_main()
      File "/home/vscode/.ansible/tmp/ansible-tmp-1655451999.4065552-22141-173774944080067/AnsiballZ_network_group.py", line 94, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/vscode/.ansible/tmp/ansible-tmp-1655451999.4065552-22141-173774944080067/AnsiballZ_network_group.py", line 40, in invoke_module
        runpy.run_module(mod_name='ansible_collections.amotolani.cisco_fmc.plugins.modules.network_group', init_globals=None, run_name='__main__', alter_sys=True)
      File "/usr/local/lib/python3.8/runpy.py", line 207, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/local/lib/python3.8/runpy.py", line 97, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_amotolani.cisco_fmc.network_group_payload_kn_3xgzc/ansible_amotolani.cisco_fmc.network_group_payload.zip/ansible_collections/amotolani/cisco_fmc/plugins/modules/network_group.py", line 410, in <module>
      File "/tmp/ansible_amotolani.cisco_fmc.network_group_payload_kn_3xgzc/ansible_amotolani.cisco_fmc.network_group_payload.zip/ansible_collections/amotolani/cisco_fmc/plugins/modules/network_group.py", line 373, in main
    UnboundLocalError: local variable '_create_obj' referenced before assignment
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1

```
Playbook used:

```
  - name: Deleting Network Group with existing network objects...
    amotolani.cisco_fmc.network_group:
      name: "dr1-sp-sa-ucs-cimc"
      state: absent
      fmc: "{{ host_ip }}"
      username: "{{ username }}"
      password: "{{ password }}"
```