### PR TITLE
added option without InsertAfter or InsertBefore and corrected some variable namings

### DIFF
--- a/amotolani/changelogs/CHANGELOG.md
+++ b/amotolani/changelogs/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Released]
 
+##[1.1.5] - 2022-06-24
+
+### Fixed
+- Deletion of network groups - when running the network_group module with "absent" state.
+- Deletion of port groups - when running the port_group module with "absent" state.
+- Running the acp_rule module without specifying "insert_after" and "insert_before" (for example if they are set to "null").
+- Variable namings for the ACP logging parameters to work.
+
+### Added
+- added option to include description for network object
+
+## [Released]
+
 ##[1.1.4] - 2022-05-26
 
 ### Added

--- a/amotolani/cisco_fmc/plugins/modules/acp_rule.py
+++ b/amotolani/cisco_fmc/plugins/modules/acp_rule.py
@@ -1078,6 +1078,9 @@ def main():
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name, section=section, insertBefore=insert_before)
         elif _create_obj and insert_after is not None:
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name, section=section, insertAfter=insert_after)
+        # Instantiate Access Rule with Section, without InsertAfter or InsertBefore
+        elif _create_obj:
+            obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name, section=section)
         elif _create_obj is False:
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name,  id=_obj1['id'])
 
@@ -1142,13 +1145,13 @@ def main():
                 if action is not None:
                     obj1.action = action
                 if enable_syslog is not None:
-                    obj1.enable_syslog = enable_syslog
+                    obj1.enableSyslog = enable_syslog
                 if log_end is not None:
-                    obj1.log_end = log_end
+                    obj1.logEnd = log_end
                 if log_begin is not None:
-                    obj1.log_begin = log_begin
+                    obj1.logBegin = log_begin
                 if send_events_to_fmc is not None:
-                    obj1.send_events_to_fmc = send_events_to_fmc
+                    obj1.sendEventsToFMC = send_events_to_fmc
 
                 if _create_obj is True:
                     fmc_obj = create_obj(obj1)

--- a/amotolani/cisco_fmc/plugins/modules/acp_rule.py
+++ b/amotolani/cisco_fmc/plugins/modules/acp_rule.py
@@ -1079,7 +1079,7 @@ def main():
         elif _create_obj and insert_after is not None:
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name, section=section, insertAfter=insert_after)
         # Instantiate Access Rule with Section, without InsertAfter or InsertBefore
-        elif _create_obj:
+        elif _create_obj and insert_before is None and insert_after is None:
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name, section=section)
         elif _create_obj is False:
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name,  id=_obj1['id'])


### PR DESCRIPTION
added option to add rules if ACP is empty, therefore "InsertAfter" or "InsertBefore" can't be set.
Corrected the log options with correct variable names expected by "AccessRules" class.