### PR TITLE
fixed check for the existing zone configuration

### DIFF
--- a/amotolani/changelogs/CHANGELOG.md
+++ b/amotolani/changelogs/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Deletion of port groups - when running the port_group module with "absent" state. 
 - Running the acp_rule module without specifying "insert_after" and "insert_before" (for example if they are set to "null").
 - Variable namings for the ACP logging parameters to work.
+- Fixed check for the existing zone configuration
 
 ## [Released]
 

--- a/amotolani/cisco_fmc/plugins/modules/security_zone.py
+++ b/amotolani/cisco_fmc/plugins/modules/security_zone.py
@@ -125,9 +125,12 @@ def main():
             if 'items' in _obj1.keys():
                 _create_obj = True
                 changed = True
-            elif _obj1['interfaceMode'] != interface_mode or _obj1['name'] != name:
+            elif _obj1['interfaceMode'] != interface_mode.upper() or _obj1['name'] != name:
                 _create_obj = False
-                changed = True 
+                changed = True
+            else:
+                changed = False
+                _create_obj = False
         else:
             if 'items' in _obj1.keys():
                 changed = False


### PR DESCRIPTION
the module would always set the "changed=true" because FMC api return "InterfaceMode" in capital letters.
also, there was missing final "else" if zone exists and nothing was changed.