### PR TITLE
support for ICMPv4 and option for FMC timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Ansible collection includes a variety of Ansible content to help automate Cisco FMC via the FMC API
 
-This collection has been tested against Cisco FMC version 6.3.0.
+This collection has been tested against Cisco FMC version 6.3.0 and 6.6.1.
 
 <!--start requires_ansible-->
 ## Ansible version compatibility

--- a/amotolani/changelogs/CHANGELOG.md
+++ b/amotolani/changelogs/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Released]
 
+##[1.1.6] - 2022-07-14
+
+### Added
+- support for ICMPv4 in port objects and ACP rules. For this feature to work, the requirenment is for ***fmcapi*** Python package to be minimum version ____
+- support for FMC timeout - define FMC API response timeout in playbook (For slower FMC servers, the default timeout (5s) can produce tasks to fail due to timeout)
+
+## [Released]
+
 ##[1.1.5] - 2022-06-24
 
 ### Fixed

--- a/amotolani/cisco_fmc/plugins/modules/acp_rule.py
+++ b/amotolani/cisco_fmc/plugins/modules/acp_rule.py
@@ -326,6 +326,12 @@ options:
       - IP address or FQDN of Cisco FMC.
     type: str
     required: true
+  fmc_timeout:
+    description:
+      - time to wait (seconds) for the API response from FMC.
+    type: int
+    default: 5
+    required: false
   username:
     description:
       - Cisco FMC Username
@@ -345,7 +351,7 @@ options:
     required: false
 '''
 
-EXAMPLES = r'''    
+EXAMPLES = r'''
 - name: Delete Access Policy Rule
   amotolani.cisco_fmc.acp_rule:
     name: Demo-Rule1900
@@ -358,7 +364,7 @@ EXAMPLES = r'''
     enabled: True
     insert_after: 1
     acp: test
-    
+
 - name: Create Access Policy Rule
   amotolani.cisco_fmc.acp_rule:
     name: Demo-Rule1900
@@ -401,11 +407,11 @@ def main():
             enabled=dict(type='bool', required=True),
             send_events_to_fmc=dict(type='bool', default=False),
             log_begin=dict(type='bool', default=False),
-            log_end=dict(type='bool', default=False),
+            log_end=dict(type='bool', default=True),
             enable_syslog=dict(type='bool', default=False),
             insert_before=dict(type='int'),
             insert_after=dict(type='int'),
-            section=dict(type='str', choices=['default', 'mandatory'], default='default'),
+            section=dict(type='str', choices=['Default', 'Mandatory'], default='Default'),
             acp=dict(type='str', required=True),
             intrusion_policy=dict(type='str'),
             file_policy=dict(type='str'),
@@ -508,6 +514,7 @@ def main():
                 )
             ),
             fmc=dict(type='str', required=True),
+            fmc_timeout=dict(type='int', required=False, default=5),
             username=dict(type='str', required=True),
             password=dict(type='str', required=True, no_log=True),
             auto_deploy=dict(type='bool', default=False)
@@ -552,6 +559,7 @@ def main():
     destination_security_group_tags = module.params['destination_security_group_tags']
     acp = module.params['acp']
     fmc = module.params['fmc']
+    fmc_timeout = module.params['fmc_timeout']
     username = module.params['username']
     password = module.params['password']
     auto_deploy = module.params['auto_deploy']
@@ -620,8 +628,12 @@ def main():
         current_config = []
         if fmc_config_name in _obj1.keys() and requested_config is not None:
 
-            # Call validate function to check that the requested config object is an existing cisco_fmc object
-            validate_multi_obj_config(requested_config=requested_config, config_class=config_class, config_name=config_name)
+            if requested_config == source_ports or requested_config == destination_ports:
+                # Call validate function to check that the port object is an existing cisco_fmc object
+                validate_port_obj_config(requested_config=requested_config, config_name=config_name)
+            else:
+                # Call validate function to check that the requested config object is an existing cisco_fmc object
+                validate_multi_obj_config(requested_config=requested_config, config_class=config_class, config_name=config_name)
 
             # rule exists, No objects of the specified type currently added, requested action for config is "add". Changed status set to True
             if len(_obj1[fmc_config_name]) == 0 and len(requested_config) > 0 and requested_config['action'] == 'add':
@@ -977,6 +989,54 @@ def main():
             else:
                 return True
 
+    def validate_port_obj_config(requested_config, config_name):
+      """
+      It is a custom version of the 'validate_multi_obj_config' function
+      Function validates that the requested configurations are existing cisco_fmc network objects
+      :param requested_config: Configuration to be added/removed from Access Rule
+      :param config_name: Configuration name in result dictionary
+      :return: boolean
+      """
+      _obj_list, port_obj, icmpv4_obj, group_obj = ([] for i in range(4))
+      if requested_config is None:
+          return True
+      else:
+          if requested_config['name'] is not None:
+              requested_config['name'] = [i for i in requested_config['name'] if i]
+              for i in requested_config['name']:
+                  config_obj = ProtocolPortObjects(fmc=fmc1, name=i)
+                  _config_obj = get_obj(config_obj)
+                  if 'items' in _config_obj:
+                      a = False
+                  else:
+                      a = True
+                  port_obj.append(a)
+                  config_obj = ICMPv4Objects(fmc=fmc1, name=i)
+                  _config_obj = get_obj(config_obj)
+                  if 'items' in _config_obj:
+                      a = False
+                  else:
+                      a = True
+                  icmpv4_obj.append(a)
+                  config_obj = PortObjectGroups(fmc=fmc1, name=i)
+                  _config_obj = get_obj(config_obj)
+                  if 'items' in _config_obj:
+                      a = False
+                  else:
+                      a = True
+                  group_obj.append(a)
+                  yy = requested_config['name'].index(i)
+                  if port_obj[yy] or icmpv4_obj[yy] or group_obj[yy]:
+                      a = True
+                  else:
+                      a = False
+                  _obj_list.append(a)
+          if not all(_obj_list):
+              result = dict(failed=True, msg='Check that the {} are existing cisco_fmc objects'.format(config_name))
+              module.exit_json(**result)
+          else:
+              return True
+
     # Custom argument validations
     # More of these are needed
     encoded_bytes = base64.b64encode(bytes(username + ':' + password, 'utf-8'))
@@ -1007,7 +1067,7 @@ def main():
     else:
         pass
 
-    with FMC(host=fmc, username=username, password=password, autodeploy=auto_deploy) as fmc1:
+    with FMC(host=fmc, username=username, password=password, timeout=fmc_timeout, autodeploy=auto_deploy) as fmc1:
 
         # Instantiate Access Rule Object with values, but first validate the Access Policy object
         validate_single_obj_config(requested_config=acp, config_name='acp', config_class=AccessPolicies)
@@ -1023,8 +1083,8 @@ def main():
                 changed = True
                 _create_obj = True
                 validate_multi_obj_config(requested_config=vlan_tags, config_name='vlan_tags', config_class=VlanTags)
-                validate_multi_obj_config(requested_config=source_ports, config_name='source_ports', config_class=ProtocolPortObjects)
-                validate_multi_obj_config(requested_config=destination_ports, config_name='destination_ports', config_class=ProtocolPortObjects)
+                validate_port_obj_config(requested_config=source_ports, config_name='source_ports')
+                validate_port_obj_config(requested_config=destination_ports, config_name='destination_ports')
                 validate_multi_obj_config(requested_config=source_port_groups, config_name='source_port_groups', config_class=PortObjectGroups)
                 validate_multi_obj_config(requested_config=destination_port_groups, config_name='destination_port_groups', config_class=PortObjectGroups)
                 validate_net_obj_config(requested_config=source_networks, config_name='source_networks')
@@ -1078,6 +1138,9 @@ def main():
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name, section=section, insertBefore=insert_before)
         elif _create_obj and insert_after is not None:
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name, section=section, insertAfter=insert_after)
+        # Instantiate Access Rule with Section, without InsertAfter or InsertBefore
+        elif _create_obj:
+            obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name, section=section)
         elif _create_obj is False:
             obj1 = AccessRules(fmc=fmc1, acp_name=acp, action=action, name=name,  id=_obj1['id'])
 
@@ -1142,13 +1205,13 @@ def main():
                 if action is not None:
                     obj1.action = action
                 if enable_syslog is not None:
-                    obj1.enable_syslog = enable_syslog
+                    obj1.enableSyslog = enable_syslog
                 if log_end is not None:
-                    obj1.log_end = log_end
+                    obj1.logEnd = log_end
                 if log_begin is not None:
-                    obj1.log_begin = log_begin
+                    obj1.logBegin = log_begin
                 if send_events_to_fmc is not None:
-                    obj1.send_events_to_fmc = send_events_to_fmc
+                    obj1.sendEventsToFMC = send_events_to_fmc
 
                 if _create_obj is True:
                     fmc_obj = create_obj(obj1)

--- a/amotolani/cisco_fmc/plugins/modules/network.py
+++ b/amotolani/cisco_fmc/plugins/modules/network.py
@@ -44,6 +44,12 @@ options:
       - IP address or FQDN of Cisco FMC.
     type: str
     required: true
+  fmc_timeout:
+    description:
+      - time to wait (seconds) for the API response from FMC.
+    type: int
+    default: 5
+    required: false
   value:
     description:
       - FMC network object value.
@@ -146,6 +152,7 @@ def main():
             network_type=dict(type='str', choices=['Host', 'Range', 'Network', 'FQDN'], required=True),
             value=dict(type='str', required=True),
             fmc=dict(type='str', required=True),
+            fmc_timeout=dict(type='int', required=False, default=5),
             username=dict(type='str', required=True),
             password=dict(type='str', required=True,  no_log=True),
             auto_deploy=dict(type='bool', default=False)
@@ -162,6 +169,7 @@ def main():
     network_type = module.params['network_type']
     value = module.params['value']
     fmc = module.params['fmc']
+    fmc_timeout = module.params['fmc_timeout']
     username = module.params['username']
     password = module.params['password']
     auto_deploy = module.params['auto_deploy']
@@ -248,7 +256,7 @@ def main():
         result = dict(failed=True, msg='Connection to FMC failed. Reason: {}'.format(err))
         module.exit_json(**result)
 
-    with FMC(host=fmc, username=username, password=password, autodeploy=auto_deploy) as fmc1:
+    with FMC(host=fmc, username=username, password=password, timeout=fmc_timeout, autodeploy=auto_deploy) as fmc1:
 
         # Instantiate Objects with values if valid ip, range or network address is provided
         if network_type == 'Host':

--- a/amotolani/cisco_fmc/plugins/modules/network_group.py
+++ b/amotolani/cisco_fmc/plugins/modules/network_group.py
@@ -49,6 +49,12 @@ options:
       - IP address or FQDN of Cisco FMC.
     type: str
     required: true
+  fmc_timeout:
+    description:
+      - time to wait (seconds) for the API response from FMC.
+    type: int
+    default: 5
+    required: false
   username:
     description:
       - Cisco FMC Username
@@ -120,6 +126,7 @@ def main():
             group_literals=dict(type='list', elements='str'),
             group_objects=dict(type='list', elements='str'),
             fmc=dict(type='str', required=True),
+            fmc_timeout=dict(type='int', required=False, default=5),
             username=dict(type='str', required=True),
             password=dict(type='str', required=True, no_log=True),
             auto_deploy=dict(type='bool', default=False)
@@ -138,6 +145,7 @@ def main():
     group_literals = module.params['group_literals']
     group_objects = module.params['group_objects']
     fmc = module.params['fmc']
+    fmc_timeout = module.params['fmc_timeout']
     username = module.params['username']
     password = module.params['password']
     auto_deploy = module.params['auto_deploy']
@@ -301,7 +309,7 @@ def main():
         result = dict(failed=True, msg='Connection to FMC failed. Reason: {}'.format(err))
         module.exit_json(**result)
 
-    with FMC(host=fmc, username=username, password=password, autodeploy=auto_deploy) as fmc1:
+    with FMC(host=fmc, username=username, password=password, timeout=fmc_timeout, autodeploy=auto_deploy) as fmc1:
 
         # creates iterable by default when not set from user ui
         if group_literals is None:

--- a/amotolani/cisco_fmc/plugins/modules/port_group.py
+++ b/amotolani/cisco_fmc/plugins/modules/port_group.py
@@ -40,6 +40,12 @@ options:
       - IP address or FQDN of Cisco FMC.
     type: str
     required: true
+  fmc_timeout:
+    description:
+      - time to wait (seconds) for the API response from FMC.
+    type: int
+    default: 5
+    required: false
   username:
     description:
       - Cisco FMC Username
@@ -79,7 +85,7 @@ EXAMPLES = r'''
     username: admin
     password: Cisco1234
 
-    
+
 - name: Remove address and port object from Port Group
   amotolani.cisco_fmc.port_group:
     name: Port-Group-2
@@ -101,6 +107,7 @@ def main():
             # group_literals=dict(type='list', elements='str'),
             group_objects=dict(type='list', elements='str'),
             fmc=dict(type='str', required=True),
+            fmc_timeout=dict(type='int', required=False, default=5),
             username=dict(type='str', required=True),
             password=dict(type='str', required=True, no_log=True),
             auto_deploy=dict(type='bool', default=False)
@@ -120,6 +127,7 @@ def main():
     group_literals = None
     group_objects = module.params['group_objects']
     fmc = module.params['fmc']
+    fmc_timeout = module.params['fmc_timeout']
     username = module.params['username']
     password = module.params['password']
     auto_deploy = module.params['auto_deploy']
@@ -179,7 +187,7 @@ def main():
         result = dict(failed=True, msg='Connection to FMC failed. Reason: {}'.format(err))
         module.exit_json(**result)
 
-    with FMC(host=fmc, username=username, password=password, autodeploy=auto_deploy) as fmc1:
+    with FMC(host=fmc, username=username, password=password, timeout=fmc_timeout, autodeploy=auto_deploy) as fmc1:
 
         # creates iterable by default when not set from user ui
         if group_literals is None:

--- a/amotolani/cisco_fmc/plugins/modules/security_zone.py
+++ b/amotolani/cisco_fmc/plugins/modules/security_zone.py
@@ -30,6 +30,12 @@ options:
       - IP address or FQDN of Cisco FMC.
     type: str
     required: true
+  fmc_timeout:
+    description:
+      - time to wait (seconds) for the API response from FMC.
+    type: int
+    default: 5
+    required: false
   username:
     description:
       - Cisco FMC Username
@@ -78,6 +84,7 @@ def main():
             name=dict(type='str', required=True),
             interface_mode=dict(type='str', choices=['routed', 'switched', 'asa', 'inline', 'passive'], required=True),
             fmc=dict(type='str', required=True),
+            fmc_timeout=dict(type='int', required=False, default=5),
             username=dict(type='str', required=True),
             password=dict(type='str', required=True,  no_log=True),
             auto_deploy=dict(type='bool', default=False)
@@ -92,6 +99,7 @@ def main():
     name = module.params['name']
     interface_mode = module.params['interface_mode']
     fmc = module.params['fmc']
+    fmc_timeout = module.params['fmc_timeout']
     username = module.params['username']
     password = module.params['password']
     auto_deploy = module.params['auto_deploy']
@@ -105,7 +113,7 @@ def main():
     def create_obj(obj):
         a = obj.post()
         return a
-    
+
     def delete_obj(obj):
         a = obj.delete()
         return a
@@ -114,7 +122,7 @@ def main():
         a = obj.put()
         return a
 
-    with FMC(host=fmc, username=username, password=password, autodeploy=auto_deploy) as fmc1:
+    with FMC(host=fmc, username=username, password=password, timeout=fmc_timeout, autodeploy=auto_deploy) as fmc1:
 
         # Instantiate Objects with values
         obj1 = SecurityZones(fmc=fmc1, name=name)
@@ -125,14 +133,19 @@ def main():
             if 'items' in _obj1.keys():
                 _create_obj = True
                 changed = True
-            elif _obj1['interfaceMode'] != interface_mode or _obj1['name'] != name:
+            elif _obj1['interfaceMode'] != interface_mode.upper() or _obj1['name'] != name:
                 _create_obj = False
-                changed = True 
+                changed = True
+            else:
+                changed = False
+                _create_obj = False
         else:
             if 'items' in _obj1.keys():
                 changed = False
+                _create_obj = False
             else:
                 changed = True
+                _create_obj = False
 
         #  Instantiate Security Zone, if it doesnt exist.
         if _create_obj:
@@ -156,7 +169,7 @@ def main():
                     msg = "An error occurred while sending request to cisco fmc"
                 result = dict(failed=True, msg=msg)
                 module.exit_json(**result)
-                
+
     result = dict(changed=changed)
     module.exit_json(**result)
 


### PR DESCRIPTION
Please note, that in order for ICMPv4 to work, the fmcapi has to be fixed, therefore my [pull request](https://github.com/marksull/fmcapi/pull/125) needs to be accepted beforehand. please wait for that before accepting.

### Added
- support for ICMPv4 in port objects and ACP rules. For this feature to work, the requirenment is for ***fmcapi*** Python package to be minimum version <tbd>
- support for FMC timeout - define FMC API response timeout in playbook (For slower FMC servers, the default timeout (5s) can produce tasks to fail due to timeout)